### PR TITLE
Add SQLite chat memory persistence

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -36,6 +36,7 @@
     "@types/uuid": "^10.0.0",
     "autoevals": "^0.0.130",
     "axios": "^1.9.0",
+    "better-sqlite3": "^12.2.0",
     "braintrust": "^0.3.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -64,6 +65,7 @@
   },
   "devDependencies": {
     "@types/chrome": "^0.0.260",
+    "@types/node": "^24.5.0",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "@typescript-eslint/eslint-plugin": "^6.15.0",

--- a/agent/src/lib/core/NxtScape.ts
+++ b/agent/src/lib/core/NxtScape.ts
@@ -4,6 +4,7 @@ import { Logging } from "@/lib/utils/Logging";
 import { BrowserContext } from "@/lib/browser/BrowserContext";
 import { ExecutionContext } from "@/lib/runtime/ExecutionContext";
 import { MessageManager } from "@/lib/runtime/MessageManager";
+import { PersistentMessageManager } from "@/lib/runtime/PersistentMessageManager";
 import { profileStart, profileEnd, profileAsync } from "@/lib/utils/profiler";
 import { BrowserAgent } from "@/lib/agent/BrowserAgent";
 import { ChatAgent } from "@/lib/agent/ChatAgent";
@@ -115,7 +116,7 @@ export class NxtScape {
         Logging.log("NxtScape", `Initializing MessageManager with ${maxTokens} token limit`);
         
         // Initialize message manager with correct token limit
-        this.messageManager = new MessageManager(maxTokens);
+        this.messageManager = new PersistentMessageManager({ maxTokens });
         
         // Create execution context with properly configured message manager
         this.executionContext = new ExecutionContext({

--- a/agent/src/lib/runtime/PersistentMessageManager.test.ts
+++ b/agent/src/lib/runtime/PersistentMessageManager.test.ts
@@ -1,0 +1,66 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { describe, expect, it } from 'vitest'
+
+import { PersistentMessageManager } from '@/lib/runtime/PersistentMessageManager'
+import { SQLiteChatMemory } from '@/lib/runtime/memory/SQLiteChatMemory'
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'browseros-chat-memory-'))
+
+const createDbPath = (name: string) => path.join(tmpRoot, `${name}.sqlite`)
+
+const probeMemory = new SQLiteChatMemory({ dbPath: createDbPath('probe') })
+const sqliteAvailable = probeMemory.isAvailable()
+
+const describeSQLite = sqliteAvailable ? describe : describe.skip
+
+describeSQLite('PersistentMessageManager with SQLiteChatMemory', () => {
+  it('persists and restores conversation history', () => {
+    const conversationId = 'persist-case'
+    const dbPath = createDbPath(conversationId)
+    const memory = new SQLiteChatMemory({ dbPath })
+    const manager = new PersistentMessageManager({ memory, conversationId })
+
+    manager.addSystem('System prompt')
+    manager.addHuman('Hello world')
+    manager.addAI('Hi there!')
+
+    const stored = memory.getMessages(conversationId)
+    expect(stored.length).toBe(3)
+
+    const reloadedMemory = new SQLiteChatMemory({ dbPath })
+    const restoredManager = new PersistentMessageManager({ memory: reloadedMemory, conversationId })
+    const restoredMessages = restoredManager.getMessages()
+
+    expect(restoredMessages.length).toBe(3)
+    expect(restoredMessages[0]._getType()).toBe('system')
+    expect(restoredMessages[1]._getType()).toBe('human')
+    expect(restoredMessages[2]._getType()).toBe('ai')
+  })
+
+  it('clears persisted history when cleared', () => {
+    const conversationId = 'clear-case'
+    const dbPath = createDbPath(conversationId)
+    const memory = new SQLiteChatMemory({ dbPath })
+    const manager = new PersistentMessageManager({ memory, conversationId })
+
+    manager.addHuman('Test message')
+    expect(memory.getMessages(conversationId).length).toBe(1)
+
+    manager.clear()
+    expect(memory.getMessages(conversationId).length).toBe(0)
+  })
+})
+
+if (!sqliteAvailable) {
+  it('falls back to in-memory storage when SQLite is unavailable', () => {
+    const manager = new PersistentMessageManager({ conversationId: 'fallback-case' })
+    manager.addHuman('Fallback message')
+    expect(manager.getMessages().length).toBe(1)
+
+    manager.clear()
+    expect(manager.getMessages().length).toBe(0)
+  })
+}

--- a/agent/src/lib/runtime/PersistentMessageManager.ts
+++ b/agent/src/lib/runtime/PersistentMessageManager.ts
@@ -1,0 +1,293 @@
+import { MessageManager, MessageType, BrowserStateMessage, TodoListMessage } from '@/lib/runtime/MessageManager'
+import { Logging } from '@/lib/utils/Logging'
+import {
+  ChatMemoryAdapter,
+  ChatMemoryMessage,
+  InMemoryChatMemory,
+  SQLiteChatMemory
+} from '@/lib/runtime/memory/SQLiteChatMemory'
+import {
+  AIMessage,
+  BaseMessage,
+  HumanMessage,
+  SystemMessage,
+  ToolMessage
+} from '@langchain/core/messages'
+
+interface PersistentMessageManagerOptions {
+  maxTokens?: number
+  conversationId?: string
+  dbPath?: string
+  memory?: ChatMemoryAdapter
+}
+
+interface SerializedContent {
+  content: string
+  isJson: boolean
+}
+
+export class PersistentMessageManager extends MessageManager {
+  private readonly memory: ChatMemoryAdapter
+  private readonly conversationId: string
+  private restoring = false
+
+  constructor(options: PersistentMessageManagerOptions = {}) {
+    super(options.maxTokens)
+
+    const envConversationId = typeof process !== 'undefined' ? process.env?.BROWSEROS_CHAT_MEMORY_ID : undefined
+    this.conversationId = options.conversationId ?? envConversationId ?? 'default'
+
+    this.memory = this.initializeMemory(options)
+    this.restoreFromMemory()
+  }
+
+  override add(message: BaseMessage, position?: number): void {
+    super.add(message, position)
+    if (!this.restoring) {
+      this.persistMessages()
+    }
+  }
+
+  override clear(): void {
+    super.clear()
+    if (!this.restoring) {
+      try {
+        this.memory.clearConversation(this.conversationId)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        Logging.log('PersistentMessageManager', `Failed to clear stored conversation: ${message}`, 'warning')
+      }
+    }
+  }
+
+  override removeLast(): boolean {
+    const removed = super.removeLast()
+    if (removed && !this.restoring) {
+      this.persistMessages()
+    }
+    return removed
+  }
+
+  override setMaxTokens(newMaxTokens: number): void {
+    super.setMaxTokens(newMaxTokens)
+    if (!this.restoring) {
+      this.persistMessages()
+    }
+  }
+
+  private initializeMemory(options: PersistentMessageManagerOptions): ChatMemoryAdapter {
+    if (options.memory) {
+      try {
+        options.memory.initialize()
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        Logging.log('PersistentMessageManager', `Failed to initialize provided chat memory: ${message}`, 'warning')
+      }
+      if (options.memory.isAvailable()) {
+        return options.memory
+      }
+
+      Logging.log('PersistentMessageManager', 'Provided chat memory is unavailable - using fallback', 'warning')
+      return this.createFallbackMemory()
+    }
+
+    const sqliteMemory = new SQLiteChatMemory({ dbPath: options.dbPath })
+    sqliteMemory.initialize()
+
+    if (sqliteMemory.isAvailable()) {
+      return sqliteMemory
+    }
+
+    Logging.log('PersistentMessageManager', 'SQLite chat memory unavailable - using in-memory fallback', 'warning')
+    return this.createFallbackMemory()
+  }
+
+  private createFallbackMemory(): ChatMemoryAdapter {
+    const fallback = new InMemoryChatMemory()
+    fallback.initialize()
+    return fallback
+  }
+
+  private restoreFromMemory(): void {
+    try {
+      const storedMessages = this.memory.getMessages(this.conversationId)
+      if (storedMessages.length === 0) {
+        return
+      }
+
+      this.restoring = true
+      for (const stored of storedMessages) {
+        const message = this.deserializeMessage(stored)
+        super.add(message)
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      Logging.log('PersistentMessageManager', `Failed to restore chat history: ${message}`, 'warning')
+    } finally {
+      this.restoring = false
+    }
+  }
+
+  private persistMessages(): void {
+    try {
+      const messages = this.getMessages().map((message, index) => this.serializeMessage(message, index))
+      this.memory.replaceConversation(this.conversationId, messages)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      Logging.log('PersistentMessageManager', `Failed to persist chat history: ${message}`, 'warning')
+    }
+  }
+
+  private serializeMessage(message: BaseMessage, sequence: number): ChatMemoryMessage {
+    const serialized = this.normalizeContent(message)
+    const metadata = this.extractMetadata(message, serialized.isJson)
+
+    const record: ChatMemoryMessage = {
+      role: this._getMessageType(message),
+      content: serialized.content,
+      sequence,
+      createdAt: Date.now()
+    }
+
+    if (metadata) {
+      record.metadata = metadata
+    }
+
+    return record
+  }
+
+  private normalizeContent(message: BaseMessage): SerializedContent {
+    const rawContent = message.content
+    if (typeof rawContent === 'string') {
+      return { content: rawContent, isJson: false }
+    }
+
+    try {
+      return { content: JSON.stringify(rawContent), isJson: true }
+    } catch {
+      return { content: String(rawContent), isJson: false }
+    }
+  }
+
+  private extractMetadata(message: BaseMessage, contentIsJson: boolean): Record<string, unknown> | undefined {
+    const metadata: Record<string, unknown> = {}
+
+    if (contentIsJson) {
+      metadata.contentIsJson = true
+    }
+
+    if (message.additional_kwargs && Object.keys(message.additional_kwargs).length > 0) {
+      metadata.additional_kwargs = message.additional_kwargs
+    }
+
+    if (message instanceof ToolMessage) {
+      const toolMessage = message as ToolMessage
+      metadata.toolCallId = toolMessage.tool_call_id
+
+      if (toolMessage.status) {
+        metadata.toolStatus = toolMessage.status
+      }
+
+      if (toolMessage.artifact !== undefined) {
+        metadata.artifact = toolMessage.artifact
+      }
+
+      if (toolMessage.metadata && Object.keys(toolMessage.metadata).length > 0) {
+        metadata.toolMetadata = toolMessage.metadata
+      }
+    }
+
+    if (message instanceof AIMessage) {
+      const aiMessage = message as AIMessage
+
+      if (Array.isArray(aiMessage.tool_calls) && aiMessage.tool_calls.length > 0) {
+        metadata.toolCalls = aiMessage.tool_calls
+      }
+
+      const invalidCalls = (aiMessage as any).invalid_tool_calls
+      if (Array.isArray(invalidCalls) && invalidCalls.length > 0) {
+        metadata.invalidToolCalls = invalidCalls
+      }
+
+      if (aiMessage.usage_metadata) {
+        metadata.usageMetadata = aiMessage.usage_metadata
+      }
+    }
+
+    return Object.keys(metadata).length > 0 ? metadata : undefined
+  }
+
+  private deserializeMessage(record: ChatMemoryMessage): BaseMessage {
+    const content = this.restoreContent(record)
+    const metadata = record.metadata ?? {}
+
+    switch (record.role) {
+      case MessageType.SYSTEM:
+        return new SystemMessage(content)
+      case MessageType.HUMAN:
+        return new HumanMessage(content)
+      case MessageType.TOOL: {
+        const toolFields: any = {
+          content,
+          tool_call_id: typeof metadata.toolCallId === 'string' ? metadata.toolCallId : ''
+        }
+
+        if (typeof metadata.toolStatus === 'string') {
+          toolFields.status = metadata.toolStatus
+        }
+
+        if (metadata.artifact !== undefined) {
+          toolFields.artifact = metadata.artifact
+        }
+
+        if (metadata.toolMetadata && typeof metadata.toolMetadata === 'object') {
+          toolFields.metadata = metadata.toolMetadata
+        }
+
+        if (metadata.additional_kwargs && typeof metadata.additional_kwargs === 'object') {
+          toolFields.additional_kwargs = metadata.additional_kwargs
+        }
+
+        return new ToolMessage(toolFields)
+      }
+      case MessageType.BROWSER_STATE:
+        return new BrowserStateMessage(typeof content === 'string' ? content : JSON.stringify(content))
+      case MessageType.TODO_LIST:
+        return new TodoListMessage(typeof content === 'string' ? content : JSON.stringify(content))
+      case MessageType.AI:
+      default: {
+        const fields: Record<string, unknown> = { content }
+
+        if (Array.isArray(metadata.toolCalls)) {
+          fields.tool_calls = metadata.toolCalls
+        }
+
+        if (Array.isArray(metadata.invalidToolCalls)) {
+          fields.invalid_tool_calls = metadata.invalidToolCalls
+        }
+
+        if (metadata.additional_kwargs && typeof metadata.additional_kwargs === 'object') {
+          fields.additional_kwargs = metadata.additional_kwargs
+        }
+
+        if (metadata.usageMetadata && typeof metadata.usageMetadata === 'object') {
+          fields.usage_metadata = metadata.usageMetadata
+        }
+
+        return new AIMessage(fields)
+      }
+    }
+  }
+
+  private restoreContent(record: ChatMemoryMessage): any {
+    if (record.metadata?.contentIsJson && record.content) {
+      try {
+        return JSON.parse(record.content)
+      } catch {
+        return record.content
+      }
+    }
+
+    return record.content
+  }
+}

--- a/agent/src/lib/runtime/memory/SQLiteChatMemory.ts
+++ b/agent/src/lib/runtime/memory/SQLiteChatMemory.ts
@@ -1,0 +1,327 @@
+import { Logging } from '@/lib/utils/Logging'
+import { MessageType } from '@/lib/runtime/MessageManager'
+
+type BetterSqlite3Module = new (path: string, options?: Record<string, unknown>) => BetterSqlite3Database
+
+interface BetterSqlite3Database {
+  prepare(sql: string): BetterSqlite3Statement
+  exec(sql: string): void
+  pragma(query: string): unknown
+  transaction<T extends unknown[]>(handler: (...args: T) => void): (...args: T) => void
+  close(): void
+}
+
+interface BetterSqlite3Statement {
+  run(...params: unknown[]): unknown
+  all(...params: unknown[]): Array<Record<string, unknown>>
+}
+
+interface PreparedStatements {
+  upsertConversation: BetterSqlite3Statement
+  deleteMessages: BetterSqlite3Statement
+  insertMessage: BetterSqlite3Statement
+  deleteConversation: BetterSqlite3Statement
+  selectMessages: BetterSqlite3Statement
+}
+
+export interface ChatMemoryMessage {
+  role: MessageType
+  content: string
+  sequence: number
+  createdAt?: number
+  metadata?: Record<string, unknown>
+}
+
+export interface ChatMemoryAdapter {
+  initialize(): void
+  isAvailable(): boolean
+  replaceConversation(conversationId: string, messages: ChatMemoryMessage[]): void
+  getMessages(conversationId: string): ChatMemoryMessage[]
+  clearConversation(conversationId: string): void
+}
+
+export interface SQLiteChatMemoryOptions {
+  dbPath?: string
+  journalMode?: string
+}
+
+function dynamicRequire(moduleName: string): any {
+  try {
+    const req = (0, eval)('require') as ((name: string) => unknown) | undefined
+    if (typeof req === 'function') {
+      return req(moduleName)
+    }
+  } catch {
+    // Ignore - module not available in this runtime
+  }
+  return null
+}
+
+export class SQLiteChatMemory implements ChatMemoryAdapter {
+  private readonly dbPath: string
+  private readonly journalMode: string
+  private database: BetterSqlite3Database | null = null
+  private statements: PreparedStatements | null = null
+  private initialized = false
+  private driver: BetterSqlite3Module | null = null
+
+  constructor(options: SQLiteChatMemoryOptions = {}) {
+    this.dbPath = this.resolveDatabasePath(options.dbPath)
+    this.journalMode = options.journalMode ?? 'WAL'
+  }
+
+  initialize(): void {
+    this.ensureDatabase()
+  }
+
+  isAvailable(): boolean {
+    return this.ensureDatabase() !== null
+  }
+
+  replaceConversation(conversationId: string, messages: ChatMemoryMessage[]): void {
+    const db = this.ensureDatabase()
+    if (!db || !this.statements) return
+
+    const now = Date.now()
+    const run = db.transaction((rows: ChatMemoryMessage[]) => {
+      this.statements!.upsertConversation.run(conversationId, now, now)
+      this.statements!.deleteMessages.run(conversationId)
+
+      for (const row of rows) {
+        const metadataJson = row.metadata ? JSON.stringify(row.metadata) : null
+        const createdAt = row.createdAt ?? now
+        this.statements!.insertMessage.run(
+          conversationId,
+          row.role,
+          row.content,
+          metadataJson,
+          row.sequence,
+          createdAt
+        )
+      }
+    })
+
+    try {
+      run(messages)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      Logging.log('SQLiteChatMemory', `Failed to persist chat history: ${message}`, 'error')
+    }
+  }
+
+  getMessages(conversationId: string): ChatMemoryMessage[] {
+    const db = this.ensureDatabase()
+    if (!db || !this.statements) return []
+
+    try {
+      const rows = this.statements.selectMessages.all(conversationId)
+      return rows.map(row => this.deserializeRow(row))
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      Logging.log('SQLiteChatMemory', `Failed to load chat history: ${message}`, 'error')
+      return []
+    }
+  }
+
+  clearConversation(conversationId: string): void {
+    const db = this.ensureDatabase()
+    if (!db || !this.statements) return
+
+    const run = db.transaction((id: string) => {
+      this.statements!.deleteMessages.run(id)
+      this.statements!.deleteConversation.run(id)
+    })
+
+    try {
+      run(conversationId)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      Logging.log('SQLiteChatMemory', `Failed to clear chat history: ${message}`, 'warning')
+    }
+  }
+
+  private ensureDatabase(): BetterSqlite3Database | null {
+    if (this.database) {
+      return this.database
+    }
+
+    try {
+      const Driver = this.loadDriver()
+      if (!Driver) {
+        throw new Error('better-sqlite3 module is not available')
+      }
+
+      this.ensureDirectoryExists(this.dbPath)
+      this.database = new Driver(this.dbPath)
+      this.database.pragma(`journal_mode = ${this.journalMode}`)
+      this.database.pragma('foreign_keys = ON')
+      this.createSchema()
+      this.prepareStatements()
+      this.initialized = true
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      Logging.log('SQLiteChatMemory', `Failed to initialize SQLite memory: ${message}`, 'warning')
+      this.database = null
+      this.statements = null
+    }
+
+    return this.database
+  }
+
+  private loadDriver(): BetterSqlite3Module | null {
+    if (this.driver) {
+      return this.driver
+    }
+
+    const loaded = dynamicRequire('better-sqlite3')
+    if (loaded) {
+      this.driver = loaded as BetterSqlite3Module
+    }
+    return this.driver
+  }
+
+  private createSchema(): void {
+    if (!this.database) return
+
+    const schema = `
+      CREATE TABLE IF NOT EXISTS conversations (
+        id TEXT PRIMARY KEY,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS chat_messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        conversation_id TEXT NOT NULL,
+        role TEXT NOT NULL,
+        content TEXT NOT NULL,
+        metadata TEXT,
+        sequence INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        FOREIGN KEY(conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS idx_chat_messages_conversation_sequence
+        ON chat_messages(conversation_id, sequence);
+    `
+
+    this.database.exec(schema)
+  }
+
+  private prepareStatements(): void {
+    if (!this.database) return
+
+    this.statements = {
+      upsertConversation: this.database.prepare(`
+        INSERT INTO conversations (id, created_at, updated_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET updated_at = excluded.updated_at
+      `),
+      deleteMessages: this.database.prepare('DELETE FROM chat_messages WHERE conversation_id = ?'),
+      insertMessage: this.database.prepare(`
+        INSERT INTO chat_messages (
+          conversation_id,
+          role,
+          content,
+          metadata,
+          sequence,
+          created_at
+        ) VALUES (?, ?, ?, ?, ?, ?)
+      `),
+      deleteConversation: this.database.prepare('DELETE FROM conversations WHERE id = ?'),
+      selectMessages: this.database.prepare(`
+        SELECT role, content, metadata, sequence, created_at
+        FROM chat_messages
+        WHERE conversation_id = ?
+        ORDER BY sequence ASC
+      `)
+    }
+  }
+
+  private deserializeRow(row: Record<string, unknown>): ChatMemoryMessage {
+    const metadataRaw = row.metadata
+    let metadata: Record<string, unknown> | undefined
+
+    if (typeof metadataRaw === 'string' && metadataRaw.length > 0) {
+      try {
+        metadata = JSON.parse(metadataRaw) as Record<string, unknown>
+      } catch {
+        metadata = undefined
+      }
+    }
+
+    return {
+      role: row.role as MessageType,
+      content: typeof row.content === 'string' ? row.content : '',
+      sequence: typeof row.sequence === 'number' ? row.sequence : Number(row.sequence ?? 0),
+      createdAt: typeof row.created_at === 'number' ? row.created_at : undefined,
+      metadata
+    }
+  }
+
+  private ensureDirectoryExists(filePath: string): void {
+    const fs = dynamicRequire('fs') as typeof import('fs') | null
+    const pathModule = dynamicRequire('path') as typeof import('path') | null
+
+    if (!fs || !pathModule) return
+
+    try {
+      const dir = pathModule.dirname(filePath)
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true })
+      }
+    } catch {
+      // Ignore directory creation errors
+    }
+  }
+
+  private resolveDatabasePath(provided?: string): string {
+    if (provided && provided.trim().length > 0) {
+      return provided
+    }
+
+    const envPath = typeof process !== 'undefined' ? process.env?.BROWSEROS_CHAT_MEMORY_PATH : undefined
+    if (envPath && envPath.trim().length > 0) {
+      return envPath
+    }
+
+    const cwd = typeof process !== 'undefined' && typeof process.cwd === 'function'
+      ? process.cwd()
+      : '.'
+
+    const pathModule = dynamicRequire('path') as typeof import('path') | null
+    if (pathModule) {
+      return pathModule.join(cwd, 'chat_memory.sqlite')
+    }
+
+    const normalized = cwd.endsWith('/') ? cwd.slice(0, -1) : cwd
+    return `${normalized}/chat_memory.sqlite`
+  }
+}
+
+export class InMemoryChatMemory implements ChatMemoryAdapter {
+  private readonly store = new Map<string, ChatMemoryMessage[]>()
+
+  initialize(): void {
+    // No-op
+  }
+
+  isAvailable(): boolean {
+    return true
+  }
+
+  replaceConversation(conversationId: string, messages: ChatMemoryMessage[]): void {
+    this.store.set(conversationId, messages.map(message => ({ ...message, metadata: message.metadata ? { ...message.metadata } : undefined })))
+  }
+
+  getMessages(conversationId: string): ChatMemoryMessage[] {
+    const messages = this.store.get(conversationId)
+    if (!messages) return []
+    return messages.map(message => ({
+      ...message,
+      metadata: message.metadata ? { ...message.metadata } : undefined
+    }))
+  }
+
+  clearConversation(conversationId: string): void {
+    this.store.delete(conversationId)
+  }
+}

--- a/agent/tsconfig.json
+++ b/agent/tsconfig.json
@@ -28,7 +28,8 @@
       "./src/types"
     ],
     "types": [
-      "chrome"
+      "chrome",
+      "node"
     ]
   },
   "include": ["src/**/*", "tests/**/*"],

--- a/agent/yarn.lock
+++ b/agent/yarn.lock
@@ -1769,6 +1769,13 @@
   dependencies:
     undici-types "~6.21.0"
 
+"@types/node@^24.5.0":
+  version "24.5.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.5.0.tgz#70a482e6b1d50e603729d74e62a9a43705ddc9d7"
+  integrity sha512-y1dMvuvJspJiPSDZUQ+WMBvF7dpnEqN4x9DDC9ie5Fs/HUZJA3wFp7EhHoVaKX/iI0cRoECV8X2jL8zi0xrHCg==
+  dependencies:
+    undici-types "~7.12.0"
+
 "@types/parse-json@^4.0.0":
   version "4.0.2"
   resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz"
@@ -2441,6 +2448,14 @@ basic-ftp@^5.0.2:
   resolved "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz"
   integrity sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==
 
+better-sqlite3@^12.2.0:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.2.0.tgz#de7c3466074f2d1a5d260f510647e822e42684d2"
+  integrity sha512-eGbYq2CT+tos1fBwLQ/tkBt9J5M3JEHjku4hbvQUePCckkvVf14xWj+1m7dGoK81M/fOjFT7yM9UMeKT/+vFLQ==
+  dependencies:
+    bindings "^1.5.0"
+    prebuild-install "^7.1.1"
+
 binary-extensions@^2.0.0, binary-extensions@^2.2.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz"
@@ -2450,6 +2465,22 @@ binary-search@^1.3.6:
   version "1.3.6"
   resolved "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz"
   integrity sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==
+
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
   version "4.12.2"
@@ -2621,6 +2652,14 @@ buffer-xor@^1.0.3:
   resolved "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
   integrity sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==
 
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
+
 buffer@^6.0.3:
   version "6.0.3"
   resolved "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz"
@@ -2767,6 +2806,11 @@ chokidar@^4.0.0:
   integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
   dependencies:
     readdirp "^4.0.1"
+
+chownr@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 chrome-trace-event@^1.0.2:
   version "1.0.4"
@@ -3173,12 +3217,24 @@ decode-named-character-reference@^1.0.0:
   dependencies:
     character-entities "^2.0.0"
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
 deep-eql@^4.1.3:
   version "4.1.4"
   resolved "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz"
   integrity sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==
   dependencies:
     type-detect "^4.0.0"
+
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@^0.1.3:
   version "0.1.4"
@@ -3249,6 +3305,11 @@ detect-libc@^1.0.3:
   resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz"
   integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
 
+detect-libc@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.0.tgz#3ca811f60a7b504b0480e5008adacc660b0b8c4f"
+  integrity sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==
+
 detect-node-es@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz"
@@ -3260,11 +3321,6 @@ devlop@^1.0.0:
   integrity sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==
   dependencies:
     dequal "^2.0.0"
-
-devtools-protocol@0.0.1464554:
-  version "0.0.1464554"
-  resolved "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1464554.tgz"
-  integrity sha512-CAoP3lYfwAGQTaAXYvA6JZR0fjGUb7qec1qf4mToyoH2TZgUFeIqYcjh6f9jNuhHfuZiEdH+PONHYrLhRQX6aw==
 
 devtools-protocol@0.0.1475386:
   version "0.0.1475386"
@@ -3421,7 +3477,7 @@ encodeurl@~2.0.0:
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
 
-end-of-stream@^1.1.0:
+end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.5"
   resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz"
   integrity sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==
@@ -3748,6 +3804,11 @@ execa@^8.0.1:
     signal-exit "^4.1.0"
     strip-final-newline "^3.0.0"
 
+expand-template@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
+  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
 expr-eval@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/expr-eval/-/expr-eval-2.0.2.tgz"
@@ -3890,6 +3951,11 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 fill-range@^7.1.1:
   version "7.1.1"
   resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz"
@@ -4004,6 +4070,11 @@ fresh@0.5.2:
   resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
 
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
@@ -4085,6 +4156,11 @@ get-uri@^6.0.1:
     basic-ftp "^5.0.2"
     data-uri-to-buffer "^6.0.2"
     debug "^4.3.4"
+
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+  integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
 
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
@@ -4410,7 +4486,7 @@ icss-utils@^5.0.0, icss-utils@^5.1.0:
   resolved "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
-ieee754@^1.2.1:
+ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -4458,6 +4534,11 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, i
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ini@~1.3.0:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 install@^0.13.0:
   version "0.13.0"
@@ -5281,6 +5362,11 @@ mimic-fn@^4.0.0:
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz"
   integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
 
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz"
@@ -5319,7 +5405,7 @@ minimatch@^9.0.3, minimatch@^9.0.4:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.2.8:
+minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -5333,6 +5419,11 @@ mitt@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
+
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
 ml-array-max@^1.2.4:
   version "1.2.4"
@@ -5426,6 +5517,11 @@ nanoid@^3.3.11:
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
+napi-build-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-2.0.0.tgz#13c22c0187fcfccce1461844136372a47ddc027e"
+  integrity sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
@@ -5477,6 +5573,13 @@ no-case@^3.0.4:
   dependencies:
     lower-case "^2.0.2"
     tslib "^2.0.3"
+
+node-abi@^3.3.0:
+  version "3.77.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.77.0.tgz#3ad90d5c9d45663420e5aa4ff58dbf4e3625419a"
+  integrity sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==
+  dependencies:
+    semver "^7.3.5"
 
 node-addon-api@^7.0.0:
   version "7.1.1"
@@ -6037,6 +6140,24 @@ preact@^10.19.3:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.27.1.tgz#c391dcad5813b67d9e04655d844d8fdc307d4252"
   integrity sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ==
 
+prebuild-install@^7.1.1:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.3.tgz#d630abad2b147443f20a212917beae68b8092eec"
+  integrity sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==
+  dependencies:
+    detect-libc "^2.0.0"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^2.0.0"
+    node-abi "^3.3.0"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^4.0.0"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
@@ -6281,6 +6402,16 @@ raw-body@2.5.2:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
 react-dom@^18.2.0:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz"
@@ -6348,7 +6479,7 @@ readable-stream@^2.3.8:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.5.0, readable-stream@^3.6.0:
+readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.5.0, readable-stream@^3.6.0:
   version "3.6.2"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -6775,6 +6906,20 @@ signal-exit@^4.0.1, signal-exit@^4.1.0:
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
 simple-git@^3.21.0:
   version "3.28.0"
   resolved "https://registry.npmjs.org/simple-git/-/simple-git-3.28.0.tgz"
@@ -6981,6 +7126,11 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
+
 strip-literal@^2.0.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz"
@@ -7073,6 +7223,16 @@ tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz"
   integrity sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==
 
+tar-fs@^2.0.0:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.3.tgz#fb3b8843a26b6f13a08e606f7922875eb1fbbf92"
+  integrity sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
 tar-fs@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz"
@@ -7083,6 +7243,17 @@ tar-fs@^3.1.0:
   optionalDependencies:
     bare-fs "^4.0.1"
     bare-path "^3.0.0"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
 
 tar-stream@^3.1.5:
   version "3.1.7"
@@ -7263,6 +7434,13 @@ tsx@^4.20.4:
   optionalDependencies:
     fsevents "~2.3.3"
 
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz"
@@ -7326,6 +7504,11 @@ undici-types@~7.10.0:
   version "7.10.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.10.0.tgz#4ac2e058ce56b462b056e629cc6a02393d3ff350"
   integrity sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==
+
+undici-types@~7.12.0:
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.12.0.tgz#15c5c7475c2a3ba30659529f5cdb4674b622fafb"
+  integrity sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==
 
 unified@^11.0.0:
   version "11.0.5"


### PR DESCRIPTION
## Summary
- add a SQLite-backed chat memory adapter with graceful in-memory fallback when the driver is unavailable
- introduce a persistent message manager that synchronizes the conversation history with the chat memory storage and use it in NxtScape
- expand project configuration and tests to cover the new persistent memory behaviour while skipping SQLite-specific checks when the driver is missing

## Testing
- yarn vitest run src/lib/runtime/PersistentMessageManager.test.ts
- yarn test *(fails: missing legacy test fixtures such as @/lib/tools/Tool.interface and other unmet dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c93a768b048333b21fac0c7f6c7f8f